### PR TITLE
Add front matter for CoC page

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Code of Conduct
+permalink: /code-of-conduct/
+---
+
 # Women of Open Source Code of Conduct
 
 ## Our Principles


### PR DESCRIPTION
The code of conduct page was 404'ing as my copy/pasta nuked the front matter. Oops.