### PR TITLE
Fix stylelint issues in theme SCSS (dead code)

### DIFF
--- a/docs/_sass/_includes/_content.scss
+++ b/docs/_sass/_includes/_content.scss
@@ -117,7 +117,6 @@
 	.highlight {
 		display: block;
 		padding: 0;
-		line-height: 1.5;
 		font-size: $p-small*0.85;
 		line-height: $p-lineheight;
 		overflow: auto;

--- a/docs/_sass/_includes/_gallery.scss
+++ b/docs/_sass/_includes/_gallery.scss
@@ -40,21 +40,9 @@
 
 .gallery--carousel {
 
-	.gallery__wrap {
-
-	}
-	
-	.gallery__item {
-
-	}
-
 	.gallery__item__link {
 		display: block;
 		pointer-events: none;
-	}
-
-	.gallery__item__image {
-
 	}
 
 	.owl-nav {

--- a/docs/_sass/_includes/_listing.scss
+++ b/docs/_sass/_includes/_listing.scss
@@ -153,11 +153,6 @@
 	font-style: italic;
 }
 
-.post__description {
-
-}
-
-
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Pagination
 


### PR DESCRIPTION
Fixes the genuine issues a lean, correctness-only stylelint config flags in the theme SCSS (it ignores the 490+ purely-stylistic findings from `standard-scss`).

- **`.highlight`** — remove `line-height: 1.5`, which was immediately overridden by `line-height: $p-lineheight` (dead declaration; a real, if tiny, bug).
- **4 empty placeholder blocks** — `.gallery__wrap`, `.gallery__item`, `.gallery__item__image` (carousel) and `.post__description`. Dead code, no CSS effect.

**Intentionally not changed:** the normalize reset re-declares `img`, and the hamburger `span:before/after` is split into two rules on purpose. These are legit theme patterns, so the lint config will exclude `no-duplicate-selectors` rather than churn the reset.

Verified: stylelint clean under the lean config, site builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)