### PR TITLE
Fix CI triggers (drop TEMP branch trigger, add workflow_dispatch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
   push:
-    branches: [main, ci/github-actions]  # TEMP: ci/github-actions to validate the workflow; remove before merge
+    branches: [main]
 
 # Cancel superseded runs on the same ref
 concurrency:


### PR DESCRIPTION
Follow-up to #20:

- Removes the temporary `ci/github-actions` push trigger (only added to validate the workflow on the branch)
- Adds `workflow_dispatch` so CI can be triggered manually — useful for validating the workflow directly (bypasses event webhooks) while diagnosing why auto-triggers aren't firing during the GitHub Actions incident

🤖 Generated with [Claude Code](https://claude.com/claude-code)