### PR TITLE
Expand Lighthouse a11y coverage to key pages

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,6 +2,19 @@
   "ci": {
     "collect": {
       "staticDistDir": "docs/_site",
+      "url": [
+        "/index.html",
+        "/about/index.html",
+        "/speakers/index.html",
+        "/speakers/silavapi-cheesley.html",
+        "/contact/index.html",
+        "/thanks/index.html",
+        "/news/index.html",
+        "/partners/index.html",
+        "/application/index.html",
+        "/code-of-conduct/index.html",
+        "/404.html"
+      ],
       "numberOfRuns": 1
     },
     "assert": {


### PR DESCRIPTION
Follow-up to the CI setup. The Lighthouse job's auto-discovery only picked up 5 pages and missed the two most accessibility-critical ones — the **speakers directory** (ARIA combobox filters) and the **contact form**.

This lists explicit **path-only** URLs so the a11y gate covers **11 pages**: home, about, speakers directory, a speaker profile, contact, thanks, news, partners, application, code-of-conduct, and 404. (With `staticDistDir`, LHCI serves the site on its own port and joins these paths to it — no host/port needed in the config.)

## Validated
Run via `workflow_dispatch` (auto-triggers are still webhook-throttled by the GitHub incident): **all 3 jobs green, Lighthouse tested all 11 pages, every one passed the ≥0.9 accessibility gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)