### PR TITLE
Fix speakers README table for markdownlint MD060

### DIFF
--- a/docs/_speakers/README.md
+++ b/docs/_speakers/README.md
@@ -69,7 +69,7 @@ page — a few short paragraphs about who you are and what you speak about.
 ## Field reference
 
 | Field | Required | Where it appears |
-|---|---|---|
+| --- | --- | --- |
 | `title` | ✅ | Browser tab / SEO `<title>`. Usually the same as `name`. |
 | `name` | ✅ | Display name — profile hero heading, "About …", and the directory card. |
 | `slug` | ✅ | The page URL: `/speakers/<slug>`. Use lowercase with hyphens. |


### PR DESCRIPTION
The CI Lint job started failing on Dependabot's #21 (bump markdownlint-cli2 to v0.23.2), which adds the new **`MD060/table-column-style`** rule. It flagged the field-reference table in `_speakers/README.md`: the separator row used tight pipes (`|---|`) while the data rows are spaced, so the table style was inconsistent.

Fix: pad the separator row (`| --- |`) to match the data rows.

Verified clean under markdownlint-cli2 v0.23.2 (0 issues). This unblocks #21 — once merged, #21's CI will pass against the updated `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)