### PR TITLE
Add Playwright end-to-end tests (desktop, tablet, mobile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,40 @@ jobs:
           pip install --quiet yamllint
           yamllint -c .yamllint.yml docs/_config.yml docs/_data/
 
+  e2e:
+    name: End-to-end (desktop, tablet, mobile)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - run: npm ci
+
+      - name: Download built site
+        uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: docs/_site
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
+
   lighthouse:
     name: Lighthouse (accessibility)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 # Node tooling (lint/CI)
 node_modules/
 .lighthouseci/
+
+# Playwright (e2e)
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "devDependencies": {
         "@eslint/js": "^9.15.0",
         "@lhci/cli": "^0.15.1",
+        "@playwright/test": "^1.48.0",
         "eslint": "^9.15.0",
+        "http-server": "^14.1.1",
         "markdownlint-cli2": "^0.23.2",
         "postcss-scss": "^4.0.9",
         "stylelint": "^16.10.0"
@@ -656,6 +658,22 @@
         "third-party-web": "latest"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
@@ -1159,6 +1177,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/axe-core": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
@@ -1275,6 +1300,26 @@
       "dependencies": {
         "bare-path": "^3.0.0"
       }
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/basic-ftp": {
       "version": "5.3.1",
@@ -1763,6 +1808,16 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.2",
@@ -2461,6 +2516,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -2802,6 +2864,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2828,6 +2911,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3128,12 +3226,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hookified": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
       "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/html-tags": {
       "version": "3.3.1",
@@ -3179,6 +3300,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3191,6 +3327,34 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -5251,6 +5415,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5485,6 +5659,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
       }
     },
     "node_modules/postcss": {
@@ -5849,6 +6069,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5983,6 +6210,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6975,6 +7209,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -7007,6 +7253,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -7059,6 +7312,33 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
     "lint:js": "eslint docs/js/personal.js",
     "lint:css": "stylelint \"docs/_sass/**/*.scss\"",
     "lint:md": "markdownlint-cli2",
-    "lint": "npm run lint:js && npm run lint:css && npm run lint:md"
+    "lint": "npm run lint:js && npm run lint:css && npm run lint:md",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
     "@lhci/cli": "^0.15.1",
+    "@playwright/test": "^1.48.0",
     "eslint": "^9.15.0",
+    "http-server": "^14.1.1",
     "markdownlint-cli2": "^0.23.2",
     "postcss-scss": "^4.0.9",
     "stylelint": "^16.10.0"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,59 @@
+// Playwright end-to-end tests for the Women of Open Source site.
+//
+// Tests run against the built static site (docs/_site) served locally, and exercise
+// real user journeys across three layouts — desktop, tablet and mobile — because
+// several past regressions were layout-specific (mobile menu, external links that
+// only broke on mobile, the speakers search/filter widget).
+//
+// Build the site first (`cd docs && bundle exec jekyll build`); the webServer below
+// then serves docs/_site. In CI the built site is downloaded from the build job.
+
+const { defineConfig, devices } = require('@playwright/test');
+
+const PORT = 4000;
+const baseURL = `http://127.0.0.1:${PORT}`;
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 7_000 },
+  fullyParallel: true,
+  // Fail the build if a test.only was committed by mistake.
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }], ['list']]
+    : [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+
+  // The same specs run against each layout. Tests that are layout-specific
+  // (e.g. the hamburger menu) adapt at runtime based on what is actually visible.
+  projects: [
+    {
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1366, height: 900 } },
+    },
+    {
+      name: 'tablet',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 820, height: 1180 }, hasTouch: true },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['Pixel 7'] },
+    },
+  ],
+
+  webServer: {
+    command: `npx http-server docs/_site -p ${PORT} -a 127.0.0.1 -c-1 --silent`,
+    url: baseURL,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/e2e/contact.spec.js
+++ b/tests/e2e/contact.spec.js
@@ -1,0 +1,27 @@
+// The contact page must present a usable form with its fields and the hCaptcha
+// container. We don't drive a real hCaptcha submission here — the widget is domain-locked
+// to production and loads from a third party — so this checks the structure the user
+// interacts with, on every layout. (The full end-to-end submission has been verified
+// manually against Formspree.)
+
+const { test, expect } = require('./fixtures');
+
+test('contact page shows a complete form with the captcha container', async ({ page }) => {
+  await page.goto('/contact/');
+
+  const form = page.locator('#contact-form');
+  await expect(form).toBeVisible();
+
+  await expect(page.locator('#contact-name')).toBeVisible();
+  await expect(page.locator('#contact-email')).toBeVisible();
+  await expect(page.locator('#contact-message')).toBeVisible();
+
+  // Required fields are actually marked required.
+  await expect(page.locator('#contact-email')).toHaveAttribute('required', '');
+  await expect(page.locator('#contact-message')).toHaveAttribute('required', '');
+
+  // The hCaptcha mount point exists (whether or not the third-party script loads).
+  await expect(page.locator('.h-captcha')).toHaveCount(1);
+
+  await expect(page.locator('#contact-form input[type="submit"]')).toBeVisible();
+});

--- a/tests/e2e/external-links.spec.js
+++ b/tests/e2e/external-links.spec.js
@@ -1,0 +1,58 @@
+// Regression guard for the mobile bug where external links did nothing when tapped.
+//
+// Cause: the theme's delegated click handler called event.preventDefault() then
+// window.open(), which mobile browsers block as a popup. The fix lets cross-origin
+// links be handled natively, and marks them target="_blank" + a safe rel on load.
+//
+// NOTE ON METHOD: headless Chromium does not reproduce a real phone's popup blocker, so
+// simply asserting "a new tab opened" would pass even with the old code. Instead we
+// SIMULATE the mobile condition by disabling window.open, then assert the link still
+// opens. With the old code (preventDefault + window.open) nothing would happen and this
+// test would fail — which is exactly what we want a regression test to do.
+
+const { test, expect } = require('./fixtures');
+
+const EXTERNAL = 'a[href^="http"]:not([href*="127.0.0.1"]):not([href*="localhost"]):not([href*="womenofopensource.org"])';
+
+test('external links are marked to open in a new tab with a safe rel', async ({ page }) => {
+  await page.goto('/application/'); // has a plain Markdown external link (the Google Form)
+
+  const externals = page.locator(EXTERNAL);
+  const count = await externals.count();
+  expect(count, 'expected at least one external link on the page').toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    const link = externals.nth(i);
+    await expect(link).toHaveAttribute('target', '_blank');
+    const rel = (await link.getAttribute('rel')) || '';
+    expect(rel, 'external links need rel=noopener').toContain('noopener');
+    expect(rel, 'external links need rel=noreferrer').toContain('noreferrer');
+  }
+});
+
+test('an external link still opens when the browser blocks window.open (as mobile does)', async ({ page, context }) => {
+  // Simulate a mobile browser refusing programmatic popups.
+  await page.addInitScript(() => { window.open = () => null; });
+
+  await page.goto('/application/');
+
+  const link = page.locator(EXTERNAL).first();
+  await expect(link).toBeVisible();
+  const href = await link.getAttribute('href');
+  const expectedHost = new URL(href).host;
+
+  // Stub just the link's destination so the new tab resolves instantly and offline.
+  const hostPattern = new RegExp(`^https?://${expectedHost.replace(/[.]/g, '\\.')}(/|$)`);
+  await context.route(hostPattern, (route) =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: '<!doctype html><title>stub</title>ok' })
+  );
+
+  const popupPromise = context.waitForEvent('page', { timeout: 7000 });
+  await link.click();
+
+  // With the old code the click was swallowed and no page ever opened → this rejects.
+  const popup = await popupPromise;
+  await popup.waitForLoadState('domcontentloaded').catch(() => {});
+  expect(popup.url()).toContain(expectedHost);
+  await popup.close();
+});

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -1,0 +1,36 @@
+// Shared test fixture used by the "our own behaviour" specs.
+//
+// It keeps tests deterministic and off the wider internet by allowing only what the site
+// genuinely needs at runtime and blocking the rest:
+//   - allowed: same-origin requests, and jQuery from Google's CDN (the theme is entirely
+//     non-functional without jQuery — no jQuery means the loading overlay never clears);
+//   - blocked: hCaptcha, Font Awesome and web fonts — none affect the behaviour under
+//     test, and the hCaptcha widget is domain-locked to production anyway.
+//
+// The external-links spec does NOT use this fixture (it manages its own routing).
+
+const base = require('@playwright/test');
+
+function isAllowed(url) {
+  return (
+    url.startsWith('http://127.0.0.1') ||
+    url.startsWith('http://localhost') ||
+    url.startsWith('data:') ||
+    url.startsWith('blob:') ||
+    url.includes('ajax.googleapis.com') // jQuery — required for the theme to run
+  );
+}
+
+const test = base.test.extend({
+  blockThirdParty: [
+    async ({ context }, use) => {
+      await context.route('**/*', (route) =>
+        isAllowed(route.request().url()) ? route.continue() : route.abort()
+      );
+      await use();
+    },
+    { auto: true },
+  ],
+});
+
+module.exports = { test, expect: base.expect };

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -1,4 +1,4 @@
-// Shared test fixture used by the "our own behaviour" specs.
+// Shared test fixture used by all specs.
 //
 // It keeps tests deterministic and off the wider internet by allowing only what the site
 // genuinely needs at runtime and blocking the rest:
@@ -7,7 +7,8 @@
 //   - blocked: hCaptcha, Font Awesome and web fonts — none affect the behaviour under
 //     test, and the hCaptcha widget is domain-locked to production anyway.
 //
-// The external-links spec does NOT use this fixture (it manages its own routing).
+// The external-links spec uses this fixture too (it needs jQuery to load) and layers on its
+// own route for the one off-site link it clicks, so that navigation resolves offline.
 
 const base = require('@playwright/test');
 

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -1,0 +1,31 @@
+const { expect } = require('@playwright/test');
+
+// The theme hides page content behind a `loading` overlay and reveals it (removing the
+// class) once the hero image has loaded. Wait for that so assertions don't race the
+// reveal animation. `classList.contains('loading')` is an exact token match, so it
+// correctly ignores the always-present `ajax-loading` class.
+async function waitForReady(page) {
+  await page.waitForFunction(() => !document.body.classList.contains('loading'));
+}
+
+// Navigate using the primary menu the way a user on this viewport would: on mobile/tablet
+// the menu is behind a hamburger toggle, on desktop the links are always visible.
+async function navigateViaMenu(page, linkText) {
+  const toggle = page.locator('.js-menu-toggle');
+  if (await toggle.isVisible()) {
+    await toggle.click();
+    await expect(page.locator('body')).toHaveClass(/menu--open/);
+  }
+  await page.locator('.menu__list__item__link', { hasText: linkText }).click();
+}
+
+// The "Showing N speaker(s)" label must always equal the number of cards actually
+// on screen — this is the invariant the directory promises the user.
+async function expectCountMatchesVisible(page) {
+  const label = await page.locator('#speaker-count').textContent();
+  const visible = await page.locator('.speaker-card:visible').count();
+  expect(Number(label), 'count label should match visible cards').toBe(visible);
+  return visible;
+}
+
+module.exports = { navigateViaMenu, expectCountMatchesVisible, waitForReady };

--- a/tests/e2e/menu.spec.js
+++ b/tests/e2e/menu.spec.js
@@ -1,0 +1,46 @@
+// Primary navigation. On narrow layouts the menu is behind a hamburger toggle; on wide
+// layouts the links are always visible. The test adapts to whichever mode this viewport
+// is actually in, and asserts the behaviour a user would expect in that mode.
+
+const { test, expect } = require('./fixtures');
+
+test('the primary menu works for this layout', async ({ page }) => {
+  await page.goto('/');
+
+  const toggle = page.locator('.js-menu-toggle');
+  const firstLink = page.locator('.menu__list__item__link').first();
+
+  if (await toggle.isVisible()) {
+    // Hamburger mode (mobile/tablet).
+    await expect(page.locator('body')).not.toHaveClass(/menu--open/);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await toggle.click();
+    await expect(page.locator('body')).toHaveClass(/menu--open/);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(firstLink).toBeVisible();
+
+    // Toggling again closes it.
+    await toggle.click();
+    await expect(page.locator('body')).not.toHaveClass(/menu--open/);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  } else {
+    // Inline mode (desktop): links are always available, no toggle needed.
+    await expect(firstLink).toBeVisible();
+  }
+});
+
+test('choosing a menu item on mobile navigates and closes the menu', async ({ page }) => {
+  await page.goto('/');
+
+  const toggle = page.locator('.js-menu-toggle');
+  test.skip(!(await toggle.isVisible()), 'no hamburger menu at this viewport');
+
+  await toggle.click();
+  await expect(page.locator('body')).toHaveClass(/menu--open/);
+
+  await page.locator('.menu__list__item__link', { hasText: 'About' }).click();
+
+  await expect(page).toHaveURL(/\/about\/$/);
+  await expect(page.locator('body')).not.toHaveClass(/menu--open/);
+});

--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -1,0 +1,36 @@
+// The theme swaps pages client-side (AJAX) rather than doing full reloads, and re-runs
+// its per-page JS afterwards. That mechanism has broken twice before (it strips inline
+// <script> tags, which is why hCaptcha and the speaker filters had to move into
+// personal.js). These tests guard that journey across all three layouts.
+
+const { test, expect } = require('./fixtures');
+const { navigateViaMenu } = require('./helpers');
+
+test('navigating Home → Speakers happens without a full page reload', async ({ page }) => {
+  await page.goto('/');
+  // This marker is wiped by any full document reload; it survives an AJAX swap.
+  await page.evaluate(() => { window.__noFullReload = true; });
+
+  await navigateViaMenu(page, 'Speakers');
+
+  await expect(page).toHaveURL(/\/speakers\/$/);
+  await expect(page.locator('#speakers-grid')).toBeVisible();
+
+  const survived = await page.evaluate(() => window.__noFullReload === true);
+  expect(survived, 'expected a client-side AJAX navigation, not a full reload').toBe(true);
+});
+
+test('speaker filters are re-initialised after AJAX navigation', async ({ page }) => {
+  await page.goto('/');
+  await navigateViaMenu(page, 'Speakers');
+  await expect(page.locator('#speakers-grid')).toBeVisible();
+
+  const total = await page.locator('.speaker-card').count();
+  expect(total, 'expected the directory to list speakers').toBeGreaterThan(0);
+
+  // If initSpeakersDirectory() had not re-run after the AJAX swap, typing would do
+  // nothing and every card would stay visible. This is the exact regression we hit before.
+  await page.fill('#speaker-search', 'zzzz-no-such-speaker-xyz');
+  await expect(page.locator('#no-results')).toBeVisible();
+  await expect(page.locator('.speaker-card:visible')).toHaveCount(0);
+});

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,37 @@
+// Smoke tests: every key page must serve successfully, render a heading, and run its
+// JavaScript without throwing. Runs on desktop, tablet and mobile.
+
+const { test, expect } = require('./fixtures');
+
+const PAGES = [
+  '/',
+  '/about/',
+  '/speakers/',
+  '/news/',
+  '/contact/',
+  '/application/',
+  '/code-of-conduct/',
+  '/partners/',
+  '/thanks/',
+];
+
+for (const path of PAGES) {
+  test(`${path} loads, renders a heading, and throws no JS errors`, async ({ page }) => {
+    const jsErrors = [];
+    page.on('pageerror', (err) => jsErrors.push(err.message));
+
+    const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
+    expect(response, `no response for ${path}`).not.toBeNull();
+    expect(response.status(), `HTTP status for ${path}`).toBeLessThan(400);
+
+    const heading = page.locator('h1').first();
+    await expect(heading, `${path} should show a top-level heading`).toBeVisible();
+    await expect(heading).not.toHaveText('');
+
+    await expect(page).toHaveTitle(/.+/);
+
+    // Give the theme's on-load JS a moment to run, then assert nothing threw.
+    await page.waitForTimeout(300);
+    expect(jsErrors, `uncaught JS errors on ${path}`).toEqual([]);
+  });
+}

--- a/tests/e2e/speakers.spec.js
+++ b/tests/e2e/speakers.spec.js
@@ -1,0 +1,94 @@
+// The speakers directory search + filters have regressed more than once. These tests
+// drive them the way a user would and assert the promised outcomes. They are written to
+// be content-independent (they read the real speaker data on the page rather than
+// hard-coding names or counts), so they keep working as speakers are added or removed.
+
+const { test, expect } = require('./fixtures');
+const { expectCountMatchesVisible, waitForReady } = require('./helpers');
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/speakers/');
+  await waitForReady(page);
+  await expect(page.locator('.speaker-card').first()).toBeVisible();
+});
+
+test('lists speakers and the "Showing N" count matches what is on screen', async ({ page }) => {
+  const total = await page.locator('.speaker-card').count();
+  expect(total).toBeGreaterThan(0);
+  const shown = await expectCountMatchesVisible(page);
+  expect(shown).toBe(total);
+});
+
+test('search narrows the list and shows an empty state for no matches', async ({ page }) => {
+  const total = await page.locator('.speaker-card').count();
+
+  // No match → zero cards + the empty-state message.
+  await page.fill('#speaker-search', 'zzzz-definitely-no-such-match');
+  await expect(page.locator('#no-results')).toBeVisible();
+  await expect(page.locator('.speaker-card:visible')).toHaveCount(0);
+  await expectCountMatchesVisible(page);
+
+  // Clearing the box brings everyone back.
+  await page.fill('#speaker-search', '');
+  await expect(page.locator('.speaker-card:visible')).toHaveCount(total);
+  await expect(page.locator('#no-results')).toBeHidden();
+});
+
+test('search matches a real speaker by name', async ({ page }) => {
+  const name = await page.locator('.speaker-card').first().getAttribute('data-name');
+  expect(name && name.length, 'first card should expose a data-name').toBeTruthy();
+
+  await page.fill('#speaker-search', name);
+
+  await expect(page.locator(`.speaker-card[data-name="${name}"]`)).toBeVisible();
+  await expect(page.locator('#no-results')).toBeHidden();
+  const shown = await expectCountMatchesVisible(page);
+  expect(shown).toBeGreaterThanOrEqual(1);
+});
+
+test('the expertise dropdown filters to speakers with that expertise', async ({ page }) => {
+  // Opening the combobox reveals the dropdown.
+  await page.locator('#expertise-search').click();
+  await expect(page.locator('#expertise-dropdown')).toHaveClass(/active/);
+
+  const tags = page.locator('#expertise-tags .filter-tag');
+  const tagCount = await tags.count();
+  expect(tagCount, 'expected expertise filter options to exist').toBeGreaterThan(0);
+
+  const value = await tags.first().getAttribute('data-value');
+  await tags.first().click();
+
+  // The combobox reflects one active selection.
+  await expect(page.locator('#expertise-search')).toHaveValue('1 selected');
+
+  // Every visible card must actually carry the chosen expertise value.
+  const shown = await expectCountMatchesVisible(page);
+  expect(shown).toBeGreaterThan(0);
+  const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const visibleCards = page.locator('.speaker-card:visible');
+  for (let i = 0; i < shown; i++) {
+    await expect(visibleCards.nth(i)).toHaveAttribute('data-expertise', new RegExp(escaped));
+  }
+});
+
+test('"Clear Filters" resets the search box and selections', async ({ page }) => {
+  const total = await page.locator('.speaker-card').count();
+
+  await page.fill('#speaker-search', 'a');
+  await page.locator('#expertise-search').click();
+  await page.locator('#expertise-tags .filter-tag').first().click();
+  await expect(page.locator('#expertise-search')).toHaveValue('1 selected');
+
+  // Dismiss the (still-open, multi-select) dropdown by clicking outside it — this also
+  // exercises the click-away-to-close behaviour, and on mobile the open panel would
+  // otherwise overlay the Clear Filters button.
+  await page.locator('h1').click();
+  await expect(page.locator('#expertise-dropdown')).not.toHaveClass(/active/);
+
+  await page.locator('#reset-filters').click();
+
+  await expect(page.locator('#speaker-search')).toHaveValue('');
+  await expect(page.locator('#expertise-search')).toHaveValue('');
+  await expect(page.locator('.speaker-card:visible')).toHaveCount(total);
+  await expect(page.locator('#no-results')).toBeHidden();
+});


### PR DESCRIPTION
## What

A Playwright end-to-end suite that drives the site the way a user would, across **desktop, tablet and mobile** layouts, plus a CI job to run it. It guards the behaviours that have regressed before.

## Coverage

| Spec | What it verifies |
|---|---|
| `smoke` | Every key page (9 URLs) loads, renders a heading, and throws **no uncaught JS errors** — on all three layouts |
| `navigation` | Home → Speakers is a **client-side AJAX swap** (no full reload), and the speaker filters **re-initialise** afterwards (the exact class of bug that broke hCaptcha and the filters before) |
| `menu` | Hamburger opens/closes and closes on selection (mobile/tablet); inline links always visible (desktop) |
| `speakers` | Search + empty state, expertise dropdown filtering, the **count-matches-visible** invariant, click-away-to-close, and Clear Filters reset |
| `external-links` | External links are marked `target="_blank"` + safe `rel`, and — **simulating a mobile browser blocking `window.open`** — still open natively |
| `contact` | Form fields + hCaptcha container present |

## Written to actually catch bugs

Per the request, these aren't written just to pass. The `external-links` regression test **simulates the real mobile condition** (disables `window.open`, which is what a phone's popup blocker effectively does) and asserts the link still opens. I verified it **fails against the pre-fix JS** (the click is swallowed, no tab opens) and passes with the fix — so it will catch a reintroduction.

The tests are content-independent where it matters (they read the real speaker data on the page rather than hard-coding names/counts), so they keep working as speakers are added or removed.

## How it runs

- Against the built static site (`docs/_site`) served locally; the config's `webServer` serves it on `127.0.0.1:4000`.
- New CI job `e2e` **reuses the site artifact** already built by the `build` job, installs Chromium, and runs `npx playwright test`. A Playwright HTML report is uploaded on every run.
- Locally: `cd docs && bundle exec jekyll build`, then `npm run test:e2e`.
- Tests allow **jQuery** (the theme's one required CDN dependency — the site is non-functional without it) and block other third parties (hCaptcha, Font Awesome, fonts) for determinism.

## Notes

- **Stacked on #28** (the external-links mobile fix). Until #28 merges, this PR's diff also shows those JS changes and the `external-links` tests depend on them — please **merge #28 first**, after which this diff narrows to just the tests.
- Surfaced along the way (not fixed here): the site loads jQuery from `ajax.googleapis.com`, so if that CDN is ever unreachable the whole site stays blank on the loading spinner. Worth considering self-hosting jQuery in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)