### PR TITLE
Add 'become our first partner' CTA to empty partners page

### DIFF
--- a/docs/_sass/_includes/_partners.scss
+++ b/docs/_sass/_includes/_partners.scss
@@ -137,6 +137,26 @@
 	}
 }
 
+// Empty state — shown until the first partner joins
+.partners-empty {
+	text-align: center;
+	max-width: 640px;
+	margin: 0 auto;
+	padding: 10px 0 20px;
+}
+
+.partners-empty__text {
+	color: $text-medium-color;
+	font-size: 16px;
+	line-height: 1.7;
+	margin-bottom: 30px;
+
+	@include mq(tabletp) {
+		font-size: 18px;
+		margin-bottom: 40px;
+	}
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - Partner Profile Pages
 
 .hero--partner {

--- a/docs/partners/index.html
+++ b/docs/partners/index.html
@@ -82,7 +82,7 @@ permalink: /partners/
 
 		<div class="partners-empty">
 			<h2 class="partners-grid__title">Be Our First Partner</h2>
-			<p class="partners-empty__text">We don't have any partners just yet — which means there's a spot reserved for a founding supporter who believes in a more inclusive open source. Could that be you?</p>
+			<p class="partners-empty__text">We don't have any partners just yet, so there's a spot reserved for a founding supporter who believes in a more inclusive open source. Could that be you?</p>
 			<a href="{{ '/contact/' | relative_url }}" class="button button--large">Become our first partner</a>
 		</div>
 

--- a/docs/partners/index.html
+++ b/docs/partners/index.html
@@ -56,11 +56,15 @@ permalink: /partners/
 
 	<div class="wrap">
 
+		{% assign published_partners = site.partners | where_exp: "partner", "partner.published != false" %}
+
+		{% if published_partners.size > 0 %}
+
 		<h2 class="partners-grid__title">Our Current Partners</h2>
 
 		<div class="partners-grid__items">
 
-			{% for project in site.partners reversed %}
+			{% for project in published_partners reversed %}
 
 			<div class="partner-card">
 				<a href="{{ project.url | relative_url }}">
@@ -73,6 +77,16 @@ permalink: /partners/
 			{% endfor %}
 
 		</div>
+
+		{% else %}
+
+		<div class="partners-empty">
+			<h2 class="partners-grid__title">Be Our First Partner</h2>
+			<p class="partners-empty__text">We don't have any partners just yet — which means there's a spot reserved for a founding supporter who believes in a more inclusive open source. Could that be you?</p>
+			<a href="{{ '/contact/' | relative_url }}" class="button button--large">Become our first partner</a>
+		</div>
+
+		{% endif %}
 
 	</div>
 

--- a/tests/e2e/partners.spec.js
+++ b/tests/e2e/partners.spec.js
@@ -1,0 +1,21 @@
+// The partners page shows the current partners, or — while there are none — a
+// "become our first partner" call to action. This test asserts whichever state the
+// site is in, so it keeps passing once a real partner is added.
+
+const { test, expect } = require('./fixtures');
+
+test('partners page shows partners, or a "become our first partner" CTA', async ({ page }) => {
+  await page.goto('/partners/');
+  await expect(page.locator('h1')).toBeVisible();
+
+  const cards = page.locator('.partner-card');
+  if ((await cards.count()) > 0) {
+    await expect(cards.first()).toBeVisible();
+  } else {
+    // Empty state: a prominent CTA button inviting the first partner, linking to contact.
+    const cta = page.locator('.partners-empty a.button');
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveText(/become our first partner/i);
+    await expect(cta).toHaveAttribute('href', /\/contact\/$/);
+  }
+});

--- a/tests/e2e/partners.spec.js
+++ b/tests/e2e/partners.spec.js
@@ -8,14 +8,18 @@ test('partners page shows partners, or a "become our first partner" CTA', async 
   await page.goto('/partners/');
   await expect(page.locator('h1')).toBeVisible();
 
+  // The two states are mutually exclusive — assert the active one AND the absence of the
+  // other, so a regression that renders both (or leaves stale markup) is caught.
   const cards = page.locator('.partner-card');
+  const cta = page.locator('.partners-empty a.button');
+
   if ((await cards.count()) > 0) {
     await expect(cards.first()).toBeVisible();
+    await expect(cta).toHaveCount(0);
   } else {
-    // Empty state: a prominent CTA button inviting the first partner, linking to contact.
-    const cta = page.locator('.partners-empty a.button');
     await expect(cta).toBeVisible();
     await expect(cta).toHaveText(/become our first partner/i);
     await expect(cta).toHaveAttribute('href', /\/contact\/$/);
+    await expect(cards).toHaveCount(0);
   }
 });


### PR DESCRIPTION
## What

While there are no published partners, the "Our Current Partners" grid rendered as a heading over an empty space. This replaces that empty state with a call to action:

- **"Be Our First Partner"** heading
- a short, warm invitation
- a **"Become our first partner"** button linking to the contact page

Once a real partner is published, the partners grid shows exactly as before — the empty state is gated on the count of *published* partners (`published != false`), so the intentional `published: false` template is ignored and does not suppress the CTA.

## Tests

Adds an e2e test (`tests/e2e/partners.spec.js`) that asserts whichever state the page is in — partner cards *or* the CTA button linking to `/contact/` — so it keeps passing after the first partner joins. Passes on desktop, tablet and mobile.

## Screenshot

_(attaching the CTA screenshot)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)