### PR TITLE
Add breathing room between the header and the hero

### DIFF
--- a/docs/_sass/_includes/_hero.scss
+++ b/docs/_sass/_includes/_hero.scss
@@ -7,17 +7,17 @@
 
 .hero {
 	position: relative;
-	margin-top: 20px;
+	margin-top: 40px;
 	padding: 60px 0 100px;
 	background: $hero-background-color;
 
 	@include mq(tabletp) {
-		margin-top: 25px;
+		margin-top: 50px;
 		padding: 120px 0 180px;
 	}
 
 	@include mq(laptop) {
-		margin-top: 30px;
+		margin-top: 60px;
 		padding: 160px 0 220px;
 	}
 


### PR DESCRIPTION
## Problem

On every page with a hero, the hero sat close under the header (a 20/25/30px gap by breakpoint), which read as cramped against the tall logo.

## Fix

Increase the base `.hero` top margin to **40 / 50 / 60px** (mobile / tablet / desktop). Because it is the shared hero style, the extra separation applies consistently everywhere a hero is used:

- Home page
- Speakers directory and speaker profile pages (`hero--single`, `hero--speaker`)
- Partners page
- About, Contact, Application, Code of Conduct, News, Thanks, 404

Measured header-to-hero gap on desktop went from **30px → 60px**.

## Verification

- Checked the home page, speakers directory, a speaker profile, and the partners page in the preview (desktop and mobile) — clear separation, no layout side effects.
- SCSS passes stylelint.
- Full e2e suite green (62 passed across desktop, tablet, mobile).

Screenshots of the speakers directory and a speaker profile after the change are attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)