### PR TITLE
Fix hero and speakers-note spacing (follow-up to #34)

### DIFF
--- a/docs/_sass/_includes/_hero.scss
+++ b/docs/_sass/_includes/_hero.scss
@@ -7,17 +7,17 @@
 
 .hero {
 	position: relative;
-	margin-top: 40px;
+	margin-top: 28px;
 	padding: 60px 0 100px;
 	background: $hero-background-color;
 
 	@include mq(tabletp) {
-		margin-top: 50px;
+		margin-top: 34px;
 		padding: 120px 0 180px;
 	}
 
 	@include mq(laptop) {
-		margin-top: 60px;
+		margin-top: 40px;
 		padding: 160px 0 220px;
 	}
 

--- a/docs/_sass/_includes/_speakers.scss
+++ b/docs/_sass/_includes/_speakers.scss
@@ -10,22 +10,22 @@
 
 .speakers-directory {
 	margin-top: -40px;
-	padding: 0 0 40px;
+	padding: 20px 0 40px;
 	background: $background-color;
 
 	@include mq(tabletp) {
 		margin-top: -60px;
-		padding: 0 0 60px;
+		padding: 20px 0 60px;
 	}
 
 	@include mq(laptop) {
 		margin-top: -60px;
-		padding: 0 0 80px;
+		padding: 20px 0 80px;
 	}
 }
 
 .speakers-cta {
-	margin-bottom: 30px;
+	margin-bottom: 20px;
 	padding: 20px 25px;
 	background: lighten($accent-color, 45%);
 	border-left: 4px solid $accent-color;


### PR DESCRIPTION
## Why

The #34 merge only included its first commit, so two spacing issues shipped to production:
- The header-to-hero gap was left at 60px (desktop) — too much white space at the top.
- The speakers-directory community note was jammed against the bottom of the hero (0px above, 30px below).

## Fix

- **Header-to-hero gap:** `40/50/60px` → `28/34/40px` (mobile/tablet/desktop). Clear separation without the excess white space.
- **Speakers-directory note:** equal `20px` above and below (was 0 above, 30 below) — a 20px section top padding plus a 20px note bottom margin.

## Verification

Measured on the local build (desktop): header-to-hero gap **40px**, note gap **20px above / 20px below**. SCSS passes stylelint; e2e smoke + speakers specs green across desktop, tablet, mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)