### PR TITLE
Add optional pronouns to speaker profiles and directory

### DIFF
--- a/docs/_layouts/speaker.html
+++ b/docs/_layouts/speaker.html
@@ -18,6 +18,7 @@ layout: default
 
 		<div class="speaker-hero-content">
 			<h1>{{ page.name }}</h1>
+			{% if page.pronouns %}<p class="speaker-hero-pronouns">{{ page.pronouns }}</p>{% endif %}
 			<p class="speaker-hero-tagline">{{ page.tagline }}</p>
 			
 			<div class="speaker-hero-meta">

--- a/docs/_layouts/speaker.html
+++ b/docs/_layouts/speaker.html
@@ -18,7 +18,9 @@ layout: default
 
 		<div class="speaker-hero-content">
 			<h1>{{ page.name }}</h1>
-			{% if page.pronouns %}<p class="speaker-hero-pronouns">{{ page.pronouns }}</p>{% endif %}
+			{% if page.pronouns %}
+			<p class="speaker-hero-pronouns">{{ page.pronouns | escape }}</p>
+			{% endif %}
 			<p class="speaker-hero-tagline">{{ page.tagline }}</p>
 			
 			<div class="speaker-hero-meta">

--- a/docs/_sass/_includes/_speakers.scss
+++ b/docs/_sass/_includes/_speakers.scss
@@ -426,7 +426,10 @@
 	}
 }
 
-.speaker-hero-pronouns {
+// Scoped to the speaker hero and given enough specificity to win over the generic
+// `.hero p` and `.hero.hero--single p` rules, which would otherwise override the colour
+// and margin here.
+.hero.hero--speaker .speaker-hero-pronouns {
 	color: $hero-text-color;
 	font-size: 15px;
 	font-weight: $regular-weight;

--- a/docs/_sass/_includes/_speakers.scss
+++ b/docs/_sass/_includes/_speakers.scss
@@ -335,6 +335,14 @@
 	}
 }
 
+.speaker-card__pronouns {
+	font-size: 13px;
+	font-weight: $regular-weight;
+	color: $text-light-color;
+	margin-top: -4px;
+	margin-bottom: 10px;
+}
+
 .speaker-card__tagline {
 	font-size: 14px;
 	color: $text-medium-color;
@@ -415,6 +423,18 @@
 	h1 {
 		color: $hero-text-color;
 		margin-bottom: 10px;
+	}
+}
+
+.speaker-hero-pronouns {
+	color: $hero-text-color;
+	font-size: 15px;
+	font-weight: $regular-weight;
+	margin-top: 6px;
+	opacity: 0.75;
+
+	@include mq(tabletp) {
+		font-size: 16px;
 	}
 }
 

--- a/docs/_speakers/README.md
+++ b/docs/_speakers/README.md
@@ -33,6 +33,7 @@ don't need (see the table below).
 ---
 title: Ada Lovelace                       # browser tab / SEO title (usually same as name)
 name: Ada Lovelace                        # display name
+pronouns: she/her                         # optional (e.g. she/her, they/them, he/him)
 slug: ada-lovelace                        # URL: /speakers/ada-lovelace
 tagline: Mathematician & the first programmer
 description: Ada Lovelace speaks about the history and future of computing.
@@ -72,6 +73,7 @@ page — a few short paragraphs about who you are and what you speak about.
 | --- | --- | --- |
 | `title` | ✅ | Browser tab / SEO `<title>`. Usually the same as `name`. |
 | `name` | ✅ | Display name — profile hero heading, "About …", and the directory card. |
+| `pronouns` | Optional | Your pronouns (e.g. `she/her`, `they/them`, `he/him`). Shown under your name on the hero and the directory card. Omit to leave it off. |
 | `slug` | ✅ | The page URL: `/speakers/<slug>`. Use lowercase with hyphens. |
 | `featured_image` | ✅ | Photo shown on the profile sidebar, the directory card, and as the social‑share image. |
 | `tagline` | Recommended | Short one‑line role/description under the name (hero + card). |

--- a/docs/_speakers/eriol-fox.md
+++ b/docs/_speakers/eriol-fox.md
@@ -1,6 +1,7 @@
 ---
 title: Eriol Fox
 name: Eriol Fox
+pronouns: they/them
 slug: eriol-fox
 tagline: Open Source Design Maintainer and Designer at The Open Home Foundation & Lockdown Systems
 featured_image: '/images/speakers/eriol-fox.jpg'

--- a/docs/_speakers/lorna-jane-mitchell.md
+++ b/docs/_speakers/lorna-jane-mitchell.md
@@ -1,6 +1,7 @@
 ---
 title: Lorna Jane Mitchell
 name: Lorna Jane Mitchell
+pronouns: she/her
 slug: lorna-jane-mitchell
 tagline: API Specialist, Developer Advocate & Technical Author
 featured_image: '/images/speakers/lorna-jane-mitchell.jpg'

--- a/docs/_speakers/mo-mcelaney.md
+++ b/docs/_speakers/mo-mcelaney.md
@@ -1,6 +1,7 @@
 ---
 title: Mo McElaney                       # browser tab / SEO title (usually same as name)
 name: Mo McElaney                        # display name
+pronouns: they/them                      # optional (e.g. she/her, they/them, he/him)
 slug: mo-mcelaney                        # URL: /speakers/mo-mcelaney
 tagline: Taking an ethical approach to open source community building.
 description: Mo speaks about ethics in tech, community, and Open Source AI.

--- a/docs/_speakers/ruth-cheesley.md
+++ b/docs/_speakers/ruth-cheesley.md
@@ -1,6 +1,7 @@
 ---
 title: Sīlavāpi Cheesley
 name: Sīlavāpi (ex Ruth) Cheesley
+pronouns: she/her
 slug: silavapi-cheesley
 tagline: Open Source Community Manager & Mautic Project Lead
 featured_image: '/images/speakers/ruth-cheesley.jpg'

--- a/docs/speakers/index.html
+++ b/docs/speakers/index.html
@@ -131,7 +131,9 @@ permalink: /speakers/
 					
 					<div class="speaker-card__content">
 						<h3 class="speaker-card__name">{{ speaker.name }}</h3>
-						{% if speaker.pronouns %}<p class="speaker-card__pronouns">{{ speaker.pronouns }}</p>{% endif %}
+						{% if speaker.pronouns %}
+						<p class="speaker-card__pronouns">{{ speaker.pronouns | escape }}</p>
+						{% endif %}
 						<p class="speaker-card__tagline">{{ speaker.tagline }}</p>
 						<p class="speaker-card__location">📍 {{ speaker.location }}</p>
 						

--- a/docs/speakers/index.html
+++ b/docs/speakers/index.html
@@ -131,6 +131,7 @@ permalink: /speakers/
 					
 					<div class="speaker-card__content">
 						<h3 class="speaker-card__name">{{ speaker.name }}</h3>
+						{% if speaker.pronouns %}<p class="speaker-card__pronouns">{{ speaker.pronouns }}</p>{% endif %}
 						<p class="speaker-card__tagline">{{ speaker.tagline }}</p>
 						<p class="speaker-card__location">📍 {{ speaker.location }}</p>
 						


### PR DESCRIPTION
## What

Adds an optional `pronouns` field to speaker profiles, shown as a subtle line directly under the speaker's name in two places:

- the **directory card**
- the **profile page hero**

It only renders when set, so it's entirely opt-in — profiles without it are unaffected.

## Details

- New `pronouns` front-matter field (e.g. `she/her`, `they/them`, `he/him`).
- Styled as muted text under the name (`.speaker-card__pronouns`, `.speaker-hero-pronouns`).
- Documented in the speaker README — added to the field-reference table and the sample template.
- Set pronouns for the four current speakers at their request: Eriol and Mo (they/them, self-declared in their own bios), Lorna and Ruth (she/her).

## Verification

Builds clean; SCSS + markdown lint clean; e2e smoke + speakers specs green across desktop, tablet, mobile. All four cards and profile heroes render pronouns correctly.

## Screenshots

Directory cards and a profile hero showing the pronoun line (attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)