### PR TITLE
Give speaker profile content breathing room below the hero

### DIFF
--- a/docs/_sass/_includes/_speakers.scss
+++ b/docs/_sass/_includes/_speakers.scss
@@ -484,16 +484,16 @@
 // Speaker Profile Section
 .speaker-profile {
 	margin-top: -40px;
-	padding: 0 0 60px;
+	padding: 20px 0 60px;
 	background: $background-color;
 
 	@include mq(tabletp) {
 		margin-top: -60px;
-		padding: 0 0 80px;
+		padding: 20px 0 80px;
 	}
 
 	@include mq(laptop) {
-		padding: 0 0 100px;
+		padding: 20px 0 100px;
 	}
 }
 


### PR DESCRIPTION
## Why

The directory spacing fix (#35) gave the community note breathing room below the hero, but **speaker profile pages were missed**: their content section (`.speaker-profile`) still had `padding-top: 0` while pulling up `-40/-60px`, so the photo/"About" content jammed right against the bottom of the hero (measured 0px gap).

## Fix

Add a `20px` top padding to `.speaker-profile` at every breakpoint — the same treatment `.speakers-directory` already uses — so the profile content sits with 20px of breathing room below the hero (measured 0px → 20px).

## Verification

Local build: profile content gap **0px → 20px**. SCSS passes stylelint; e2e smoke + speakers specs green across desktop, tablet, mobile. Before/after screenshots attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)