### PR TITLE
Update LinkedIn URL and X branding

### DIFF
--- a/docs/_README.md
+++ b/docs/_README.md
@@ -127,7 +127,7 @@ The images in the `/demo/` subfolder are used in the demo project, post and page
 
 `favicon.png` – you should replace this with the favicon image you'd like to use for your website.
 
-`social.jpg` – this image is used by default as the meta image on the Home and Blog pages. This shows up on social shares of your page, for example Facebook or Twitter – so you should change it to a relevant image, or change the image URL in that page's Front Matter (see below).
+`social.jpg` – this image is used by default as the meta image on the Home and Blog pages. This shows up on social shares of your page, for example Facebook or X – so you should change it to a relevant image, or change the image URL in that page's Front Matter (see below).
 
 ---
 

--- a/docs/_data/settings.yml
+++ b/docs/_data/settings.yml
@@ -50,7 +50,7 @@ contact_settings:
 
 social_settings:
   facebook_url: 'https://facebook.com/WomenOfOpenSource'
-  twitter_url: 'https://twitter.com/WomenOfOS'
+  x_url: 'https://x.com/WomenOfOS'
   instagram_url: 'https://instagram.com/WomenOfOpenSource'
   snapchat_url: ''
   youtube_url: ''
@@ -74,7 +74,7 @@ social_settings:
   soundcloud_url: ''
   spotify_url: ''
   bandcamp_url: ''
-  linkedin_url: 'https://linkedin.com/company/womenofopensource'
+  linkedin_url: 'https://www.linkedin.com/company/women-of-open-source/'
 
 color_settings:
   background_color: '#ffffff'

--- a/docs/_includes/socials.html
+++ b/docs/_includes/socials.html
@@ -4,7 +4,11 @@
 	{% assign platform = url[0] | remove: '_url' | replace: '-', ' ' | capitalize | replace: 'Github', 'GitHub' | replace: 'Linkedin', 'LinkedIn' | replace: 'Youtube', 'YouTube' %}
 	<li class="socials__item">
 		<a href="{{ url[1] }}" target="_blank" rel="noopener noreferrer" class="socials__item__link" aria-label="{{ platform }} (opens in new tab)">
+			{% if url[0] == 'x_url' %}
+			{% include x-icon.html %}
+			{% else %}
 			<i class="fab fa-{{ url[0] | replace: 'facebook', 'facebook-f' | remove: '_url' }}" aria-hidden="true"></i>
+			{% endif %}
 		</a>
 	</li>
 	{% endif %}

--- a/docs/_includes/x-icon.html
+++ b/docs/_includes/x-icon.html
@@ -1,0 +1,3 @@
+<svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;">
+	<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.451-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"/>
+</svg>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -28,7 +28,7 @@
 	<title>{% if page.url == "/" %}{{ site.data.settings.basic_settings.site_title }} – {{ page.title }}{% else %}{{ page.title }} – {{ site.data.settings.basic_settings.site_title }}{% endif %}</title>
 	<meta name="description" content="{{ page.description | strip_html | xml_escape }}">
 
-	<!-- Twitter Card -->
+	<!-- X Card (metadata names remain twitter:* per the platform specification) -->
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:title" content="{% if page.url == "/" %}{{ site.data.settings.basic_settings.site_title }} – {{ page.title }}{% else %}{{ page.title }} – {{ site.data.settings.basic_settings.site_title }}{% endif %}">
 	<meta name="twitter:description" content="{{ page.description | strip_html | xml_escape }}">

--- a/docs/_layouts/speaker.html
+++ b/docs/_layouts/speaker.html
@@ -56,9 +56,9 @@ layout: default
 					</svg>
 				</a>
 				{% endif %}
-				{% if page.profiles.twitter %}
-				<a href="{{ page.profiles.twitter }}" target="_blank" rel="noopener noreferrer" class="speaker-hero-profile-link" aria-label="Twitter/X">
-					<i class="fab fa-twitter" aria-hidden="true"></i>
+				{% if page.profiles.x %}
+				<a href="{{ page.profiles.x }}" target="_blank" rel="noopener noreferrer" class="speaker-hero-profile-link" aria-label="X">
+					{% include x-icon.html %}
 				</a>
 				{% endif %}
 				{% if page.profiles.github %}

--- a/docs/_speakers/README.md
+++ b/docs/_speakers/README.md
@@ -52,7 +52,7 @@ profiles:                                 # all optional — only those you add 
   linkedin: https://linkedin.com/in/ada
   mastodon: https://mastodon.social/@ada
   bluesky: https://bsky.app/profile/ada.example
-  twitter: https://twitter.com/ada
+  x: https://x.com/ada
   github: https://github.com/ada
   website: https://ada.example
 talks:                                    # optional — one entry per talk
@@ -82,7 +82,7 @@ page — a few short paragraphs about who you are and what you speak about.
 | `expertise` | Recommended | List of topics. Shown as tags (sidebar + card) and powers the **expertise filter**. |
 | `employer` | Optional | Shown on the hero (💼). Also searchable. Not shown on the card. |
 | `languages` | Optional | List. Shown in the sidebar "Languages" box (hidden if omitted). |
-| `profiles` | Optional | Social/profile links shown as icons on the hero. Supported keys: `sessionize`, `linkedin`, `mastodon`, `bluesky`, `twitter`, `github`, `website`. Only the ones you add are shown. |
+| `profiles` | Optional | Social/profile links shown as icons on the hero. Supported keys: `sessionize`, `linkedin`, `mastodon`, `bluesky`, `x`, `github`, `website`. Only the ones you add are shown. |
 | `talks` | Optional | List of talks in the "Speaking Topics" section. Each has `title`, `abstract`, and optional `delivered_at` (a list of events). |
 | `hero_image` | Optional | Banner image behind the hero. Falls back to a default community photo if omitted. |
 | *(body text)* | Recommended | Everything below the front matter is your **bio** (the "About" section), written in Markdown. |

--- a/docs/_speakers/lorna-jane-mitchell.md
+++ b/docs/_speakers/lorna-jane-mitchell.md
@@ -21,7 +21,7 @@ profiles:
   linkedin: https://linkedin.com/in/lornajane
   mastodon: https://indieweb.social/@lornajane
   bluesky: https://bsky.app/profile/lornajane.net
-  twitter: https://twitter.com/lornajane
+  x: https://x.com/lornajane
   github: https://github.com/lornajane
   website: https://lornajane.net
 talks:

--- a/docs/_speakers/peculiaruc.md
+++ b/docs/_speakers/peculiaruc.md
@@ -21,7 +21,7 @@ profiles:
   sessionize: https://sessionize.com/peculiar
   linkedin: https://www.linkedin.com/in/peculiar-c-umeh/
   mastodon: https://mastodon.online/@peculiar
-  twitter: https://twitter.com/peculiarpec
+  x: https://x.com/peculiarpec
   github: https://github.com/peculiaruc
   website:
 talks:

--- a/docs/_speakers/ruth-cheesley.md
+++ b/docs/_speakers/ruth-cheesley.md
@@ -20,7 +20,7 @@ profiles:
   sessionize: https://sessionize.com/silavapi
   linkedin: https://linkedin.com/in/ruthcheesley
   mastodon: https://mastodon.online/@rcheesley
-  twitter: https://twitter.com/rcheesley
+  x: https://x.com/rcheesley
   github: https://github.com/rcheesley
   website: https://ruthcheesley.co.uk
 talks:


### PR DESCRIPTION
The site linked to an outdated LinkedIn company slug and still presented X as Twitter with the former bird icon.

This updates the organization and speaker links to their current LinkedIn and X URLs, replaces the legacy Twitter icon with a reusable inline X logo, and aligns labels and contributor documentation with the current branding. The `twitter:*` card metadata names remain unchanged because those names are still required by the platform specification.