### PR TITLE
Fix Dependabot alerts: pin patched tmp and uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2612,19 +2612,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -5443,16 +5430,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7065,30 +7042,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -7279,14 +7239,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,9 @@
     "markdownlint-cli2": "^0.23.2",
     "postcss-scss": "^4.0.9",
     "stylelint": "^16.10.0"
+  },
+  "overrides": {
+    "tmp": "^0.2.6",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## What

Resolves the fixable Dependabot alerts in `package-lock.json` (all dev/CI tooling, none shipped to the site) by adding an npm `overrides` block that pins two transitive dependencies to their patched versions:

```json
"overrides": {
  "tmp": "^0.2.6",
  "uuid": "^11.1.1"
}
```

This clears three alerts, all pulled in via `@lhci/cli` (Lighthouse CI):

| Alert | Severity | Package | Now |
|---|---|---|---|
| #13 | high | `tmp` < 0.2.6 (path traversal) | tmp 0.2.7 ✅ |
| #9 | low | `tmp` <= 0.2.3 (symlink write) | tmp 0.2.7 ✅ |
| #12 | medium | `uuid` < 11.1.1 (buffer bounds) | uuid 11.1.1 ✅ |

## Why overrides

`npm audit fix --force` would have **downgraded `@lhci/cli` from 0.15.1 to 0.1.0** (a major regression), so it was not an option. `@lhci/cli` is already on its latest release, so an override is the correct way to pull the patched transitive versions.

## Verification

- Confirmed `@lhci` imports `uuid` via `require('uuid')` (compatible with v11's named exports) and `tmp` likewise, so the major `uuid` bump is safe.
- Ran the **Lighthouse CI job end-to-end locally** with the overrides: healthcheck passed, Chrome found, and it completed on all 11 configured pages.
- `@lhci/cli` and Playwright both still report their expected versions.

## Not covered here

The fourth alert, **`extract-zip` <= 2.0.1 (#18, high)**, has **no patched version available** upstream. It arrives via `puppeteer-core` (inside `@lhci`) and is used only to unpack the Chrome download during CI (from a trusted Google URL, not attacker-controlled input), so the practical risk is very low. It's dismissed separately as tolerable risk and will re-surface automatically once a patched `extract-zip` ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)