### PR TITLE
Pin GitHub Actions to commit SHAs and verify npm signatures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,18 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates. Security updates run automatically regardless of
+# this file; this enables scheduled version-bump PRs for the ecosystems we use.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # npm dev/CI tooling (package.json + package-lock.json at the repo root)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions in .github/workflows. Dependabot understands the
+  # SHA-pinned-with-version-comment format and bumps both together.
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
       # Point Bundler at docs/Gemfile from any working directory (absolute path)
       BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "3.3.4"
           bundler-cache: true
@@ -40,7 +40,7 @@ jobs:
         run: htmlproofer docs/_site --disable-external --no-enforce-https --checks Links,Images
 
       - name: Upload built site
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: site
           path: docs/_site
@@ -50,14 +50,17 @@ jobs:
     name: Lint (JS, SCSS, Markdown, YAML)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: npm
 
       - run: npm ci
+
+      - name: Verify npm package signatures
+        run: npm audit signatures
 
       - name: ESLint (personal.js)
         run: npm run lint:js
@@ -68,7 +71,7 @@ jobs:
       - name: markdownlint (content)
         run: npm run lint:md
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.x"
 
@@ -82,9 +85,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: npm
@@ -92,7 +95,7 @@ jobs:
       - run: npm ci
 
       - name: Download built site
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: site
           path: docs/_site
@@ -105,7 +108,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: playwright-report
@@ -116,9 +119,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: npm
@@ -126,7 +129,7 @@ jobs:
       - run: npm ci
 
       - name: Download built site
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: site
           path: docs/_site


### PR DESCRIPTION
## Why

Follow-up to the Dependabot fix (#43). Our npm dependencies are already effectively hash-pinned (the committed `package-lock.json` records SHA-512 `integrity` hashes for all 596 packages, and CI installs with `npm ci`, which verifies them). The remaining "pin to hashes" gap was the **GitHub Actions**, which were pinned to mutable major tags (`@v4`, `@v1`, ...). A tag can be force-moved to point at different code, so this pins each action to a full commit SHA.

## Changes

- **Pin every workflow action to a commit SHA**, with the human-readable version as a trailing comment (so Dependabot can still propose updates and reviewers can read it):

  | Action | Pinned to |
  |---|---|
  | `actions/checkout` | `11d5960…` # v4.4.0 |
  | `ruby/setup-ruby` | `95ef2b0…` # v1.321.0 |
  | `actions/setup-node` | `49933ea…` # v4.4.0 |
  | `actions/setup-python` | `a26af69…` # v5.6.0 |
  | `actions/upload-artifact` | `ea165f8…` # v4.6.2 |
  | `actions/download-artifact` | `d3f86a1…` # v4.3.0 |

  SHAs were resolved directly from each action's official repository.

- **Add `npm audit signatures`** to the lint job (after `npm ci`) to verify installed packages carry valid npm registry signatures. Verified locally: **all 596 packages have verified registry signatures** (47 also have provenance attestations), so this passes cleanly and won't produce false failures.

## Notes

- Dependabot's GitHub Actions ecosystem understands SHA-pinned-with-version-comment entries and will keep proposing updates against the comment, so we don't lose automated update PRs.
- No functional change to what the workflow does; only how the actions are referenced, plus the new signature-verification step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)