### PR TITLE
Fix CodeQL sanitization alerts in e2e test helpers

### DIFF
--- a/tests/e2e/external-links.spec.js
+++ b/tests/e2e/external-links.spec.js
@@ -42,9 +42,10 @@ test('an external link still opens when the browser blocks window.open (as mobil
   const expectedHost = new URL(href).host;
 
   // Stub just the link's destination so the new tab resolves instantly and offline.
-  const hostPattern = new RegExp(`^https?://${expectedHost.replace(/[.]/g, '\\.')}(/|$)`);
-  await context.route(hostPattern, (route) =>
-    route.fulfill({ status: 200, contentType: 'text/html', body: '<!doctype html><title>stub</title>ok' })
+  // Match on the exact host via a predicate (no regex built from the URL).
+  await context.route(
+    (u) => u.host === expectedHost,
+    (route) => route.fulfill({ status: 200, contentType: 'text/html', body: '<!doctype html><title>stub</title>ok' })
   );
 
   const popupPromise = context.waitForEvent('page', { timeout: 7000 });

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -13,12 +13,19 @@
 const base = require('@playwright/test');
 
 function isAllowed(url) {
+  if (url.startsWith('data:') || url.startsWith('blob:')) return true;
+  let hostname;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  // Match on the exact hostname (not a substring), so lookalikes such as
+  // ajax.googleapis.com.evil.com are not allowed through.
   return (
-    url.startsWith('http://127.0.0.1') ||
-    url.startsWith('http://localhost') ||
-    url.startsWith('data:') ||
-    url.startsWith('blob:') ||
-    url.includes('ajax.googleapis.com') // jQuery — required for the theme to run
+    hostname === '127.0.0.1' ||
+    hostname === 'localhost' ||
+    hostname === 'ajax.googleapis.com' // jQuery — required for the theme to run
   );
 }
 


### PR DESCRIPTION
## What

Fixes the two JavaScript CodeQL code-scanning alerts, both in the Playwright e2e helpers (test-only code, not shipped to the site).

### 1. `js/incomplete-url-substring-sanitization` (high) - `tests/e2e/fixtures.js`

The third-party request blocker allowed jQuery with `url.includes('ajax.googleapis.com')`. A substring check would also allow lookalikes like `https://ajax.googleapis.com.evil.com` or `https://evil.com/?x=ajax.googleapis.com`. Now it parses the URL and compares the **exact hostname**:

```js
const hostname = new URL(url).hostname;
return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === 'ajax.googleapis.com';
```

### 2. `js/incomplete-sanitization` (high) - `tests/e2e/external-links.spec.js`

The stub route was built as a regex from the link's host, escaping only `.` (not backslashes or other metacharacters). Replaced with Playwright's **URL-predicate matcher**, so no regex is built from the URL at all:

```js
await context.route((u) => u.host === expectedHost, (route) => route.fulfill({ ... }));
```

## Verification

No behaviour change. The `external-links` and `smoke` specs pass across desktop, tablet and mobile (33 tests) - the fixture still allows jQuery + same-origin and blocks everything else, and the external-link stub still matches the popup destination.

## Related

The other four code-scanning alerts (`actions/missing-workflow-permissions`) are fixed in #44 by adding a top-level `permissions: contents: read` to the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)