### PR TITLE
Restore least-privilege workflow permissions (missed in #44 merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for GITHUB_TOKEN across all jobs (they only read the
+# repo and handle build artifacts; nothing needs write scopes).
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build + HTML proofer


### PR DESCRIPTION
## Why

#44 was merged at an earlier commit than its final state (a partial merge, same as happened with #34), so the SHA-pinning, npm-signature check and Dependabot config all landed, but the **`permissions` commit was left behind**. As a result `ci.yml` on `main` still has no `permissions` block, and the four CodeQL `actions/missing-workflow-permissions` alerts (#1, #3, #7, #8) are still open.

## What

Restores that commit: a top-level least-privilege block on the workflow.

```yaml
permissions:
  contents: read
```

This sets the default `GITHUB_TOKEN` scope for all four jobs. They only read the repo and handle build artifacts (artifact upload/download use the Actions runtime token, not `GITHUB_TOKEN`), so nothing needs write scopes. It was already verified green on #44's CI before the merge.

Once merged, CodeQL re-scans `main` and the four permission alerts auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)